### PR TITLE
Fix: Resolve NETSDK1022 and subsequent compilation errors

### DIFF
--- a/AgentePedidoCS.Agent/AgentePedidoCS.Agent.csproj
+++ b/AgentePedidoCS.Agent/AgentePedidoCS.Agent.csproj
@@ -24,9 +24,4 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="OrderPrioritizerAgent.cs" />
-    <Compile Include="NotificationAgent.cs" />
-  </ItemGroup>
-
 </Project>

--- a/AgentePedidoCS.Agent/OrderVerifierAgent.cs
+++ b/AgentePedidoCS.Agent/OrderVerifierAgent.cs
@@ -1,6 +1,7 @@
 // AgentePedidoCS/AgentePedidoCS.Agent/OrderVerifierAgent.cs
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
 using AgentePedidoCS.Agent.Tools;
 using Microsoft.Extensions.Logging;
 using System;


### PR DESCRIPTION
I removed duplicate 'Compile' items from AgentePedidoCS.Agent.csproj to fix error NETSDK1022. This error occurred because .cs files were explicitly included while the .NET SDK already includes them by default.

Additionally, I added a missing 'using Microsoft.SemanticKernel.Connectors.OpenAI;' directive in OrderVerifierAgent.cs. This resolved compilation errors CS0246 (OpenAIPromptExecutionSettings not found) and CS0103 (ToolCallBehavior not found) that appeared after the initial fix and project structure analysis.

The project now builds successfully.